### PR TITLE
Add Japanese locale

### DIFF
--- a/locale/ja/lead.cfg
+++ b/locale/ja/lead.cfg
@@ -1,0 +1,46 @@
+[entity-name]
+lead-ore=鉛鉱石
+lead-chest=鉛製チェスト
+
+[autoplace-control-names]
+lead-ore=[item=lead-ore] 鉛鉱石
+
+[item-name]
+lead-ore=鉛鉱石
+lead-dust=鉛鉱石の粉末
+lead-plate=鉛版
+lead-alloy=__ITEM__lead-plate__
+enriched-lead=純化鉛
+lead-chest=鉛製チェスト
+compressed-lead-ore=Compressed lead ore
+
+[item-description]
+lead-ore=精錬して鉛版を得ることができます
+enriched-lead=精錬して効率的に鉛版を得ることができます
+
+[technology-name]
+enriched-lead=鉛純化
+lead-matter-processing=鉛変換
+
+[technology-description]
+enriched-lead=鉛鉱石を硫酸[fluid=sulfuric-acid] と水で[fluid=water] 処理し、収量を改善します。副産物として汚水[fluid=dirty-water] を生産します。
+
+[recipe-name]
+enriched-lead=__ITEM__enriched-lead__
+lead-plate=__ITEM__lead-plate__
+smelt-compressed-lead-ore=__ITEM__lead-plate__
+lead-dust=__ITEM__lead-dust__
+dirty-water-filtration-lead=汚水分離[item=lead-ore]
+
+[recipe-description]
+enriched-lead=鉛鉱石を硫酸[fluid=sulfuric-acid] と水で[fluid=water] 処理し、収量を改善します。副産物として汚水[fluid=dirty-water] を生産します。
+
+dirty-water-filtration-lead=汚水をろ過し、鉛鉱石[item=lead-ore] と石[item=stone] を確率的に生産します。
+
+# Settings
+
+[mod-setting-name]
+bzlead-more-entities=実験的: 鉛製エンティティ
+
+[mod-setting-description]
+bzlead-more-entities=鉛製エンティティ(現在は鉛製チェストのみ)。現時点では実験的で、長期的サポートの保証はなし。

--- a/locale/ja/lead.cfg
+++ b/locale/ja/lead.cfg
@@ -35,7 +35,7 @@ dirty-water-filtration-lead=汚水分離[item=lead-ore]
 [recipe-description]
 enriched-lead=鉛鉱石を硫酸[fluid=sulfuric-acid] と水で[fluid=water] 処理し、収量を改善します。副産物として汚水[fluid=dirty-water] を生産します。
 
-dirty-water-filtration-lead=汚水をろ過し、鉛鉱石[item=lead-ore] と石[item=stone] を確率的に生産します。
+dirty-water-filtration-lead=汚水をろ過し、鉛鉱石[item=lead-ore] と銅鉱石[item=copper-ore] と石[item=stone] を確率的に生産します。
 
 # Settings
 


### PR DESCRIPTION
I have translated text in this MOD into Japanese.

`compressed-lead-ore` is left untranslated because it is for [Simple Compress](https://mods.factorio.com/mod/SimpleCompress) but it only has English and German texts at the moment.