### PR TITLE
Change translation wording to match with K2

### DIFF
--- a/locale/ja/lead.cfg
+++ b/locale/ja/lead.cfg
@@ -30,7 +30,7 @@ enriched-lead=__ITEM__enriched-lead__
 lead-plate=__ITEM__lead-plate__
 smelt-compressed-lead-ore=__ITEM__lead-plate__
 lead-dust=__ITEM__lead-dust__
-dirty-water-filtration-lead=汚水分離[item=lead-ore]
+dirty-water-filtration-lead=汚水をろ過[item=lead-ore]
 bz-lead-ingot=鉛のインゴット
 
 [recipe-description]


### PR DESCRIPTION
This PR updates ja translation of dirty-water-filtration-lead to match with K2's existing recipes.
