### PR TITLE
Update ja (20250412)

### DIFF
--- a/locale/ja/lead.cfg
+++ b/locale/ja/lead.cfg
@@ -18,6 +18,7 @@ chelated-lead=キレート化鉛
 lead-expansion-bolt=鉛拡張ボルト
 lead-lithium-eutectic=鉛リチウム共晶
 
+
 [item-description]
 lead-ore=製錬して鉛板を得ることができます
 enriched-lead=製錬して効率的に鉛板を得ることができます
@@ -41,6 +42,7 @@ lead-dust=__ITEM__lead-dust__
 dirty-water-filtration-lead=汚水をろ過[item=lead-ore]
 bz-lead-ingot=鉛インゴット
 casting-lead=鉛板(鋳造)
+casting-lead-expansion-bolt=鉛拡張ボルト
 molten-lead-from-lava=溶融鉛(溶岩)
 lead-dechelation=鉛の脱キレート化
 alternative-metallic-asteroid-crushing=代替金属質アステロイド破砕


### PR DESCRIPTION
Update Japanese translation against c40e682

This only adds missing translation for `casting-lead-expansion-bolt`.